### PR TITLE
release-v1: Fix bundle bugs

### DIFF
--- a/ts/src/service.ts
+++ b/ts/src/service.ts
@@ -152,7 +152,6 @@ export class Service {
                   merkleRoot: merkleRootToBeHexString(this.preMerkleRoot),
                 },
                 {
-                  taskId: task_id,
                   postMerkleRoot: merkleRootToBeHexString(this.merkleRoot),
                 },
                 {}
@@ -174,7 +173,7 @@ export class Service {
             merkleRoot: merkleRootToBeHexString(this.merkleRoot),
             preMerkleRoot: preMerkleRootStr,
             taskId: task_id,
-            bundleIndeX: this.bundleIndex,
+            bundleIndex: this.bundleIndex,
           });
 
           try {
@@ -298,7 +297,14 @@ export class Service {
           BigInt(instances[6].toString()),
           BigInt(instances[7].toString()),
         ]);
-        this.bundleIndex = await this.findBundleIndex(this.merkleRoot);
+        this.preMerkleRoot = new BigUint64Array([
+          BigInt(instances[0].toString()),
+          BigInt(instances[1].toString()),
+          BigInt(instances[2].toString()),
+          BigInt(instances[3].toString()),
+        ]);
+
+        this.bundleIndex = await this.findBundleIndex(this.preMerkleRoot);
         console.log("updated merkle root", this.merkleRoot, this.bundleIndex);
       }
     }


### PR DESCRIPTION
(1)
const prevBundle = await modelBundle.findOneAndUpdate(
  {
    merkleRoot: merkleRootToBeHexString(this.preMerkleRoot),
  },
  {
    taskId: task_id,
    postMerkleRoot: merkleRootToBeHexString(this.merkleRoot),
  },
  {}
);

Will also udpate taskId of prevBundle which should not be updated, this patch fix it.

(2)
      let task = await get_latest_proof(taskid);
      console.log("latest taskId got from remote:", task?._id);
      console.log("latest task", task?.instances);
      if (task) {
        const instances = ZkWasmUtil.bytesToBN(task?.instances);
        this.merkleRoot = new BigUint64Array([
          BigInt(instances[4].toString()),
          BigInt(instances[5].toString()),
          BigInt(instances[6].toString()),
          BigInt(instances[7].toString()),
        ]);
        this.bundleIndex = await this.findBundleIndex(this.merkleRoot);
        console.log("updated merkle root", this.merkleRoot, this.bundleIndex);

In remote=1 mode, the current merkleRoot got from latest proof is postMerkleRoot whos bundleIndex is 0.
Which will cause failure like below in findBundleIndex(): "fatal: bundle for 6892457031230806253,4612773631806820544,96712576773 87512379,995875682240349739 is not recorded"

The real merkleRoot which bundleIndex should be restore from is
          BigInt(instances[0].toString()),
          BigInt(instances[1].toString()),
          BigInt(instances[2].toString()),
          BigInt(instances[3].toString()),

(3)
Fix typo bundleIndeX to bundleIndex