### PR TITLE
Add MD5-based database migration system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.js.map
 **/node_modules
 target
+plan.md

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -134,41 +134,7 @@ export const jobSchema = new mongoose.Schema({
     },
 });
 
-export const bundleSchema = new mongoose.Schema({
-    merkleRoot: {
-        type: String,
-        required: true,
-        unique: true,
-    },
-    preMerkleRoot: {
-        type: String,
-        default: '',
-    },
-    postMerkleRoot: {
-        type: String,
-        default: '',
-    },
-    taskId: {
-        type: String,
-        default: '',
-    },
-    withdrawArray: [{
-          address: { type: String, default:'' },
-          amount: { type: BigInt, default:'' },
-    }],
-    settleStatus: {
-        type: String,
-        default: 'waiting',  // wait-for settle, settle failed, settle done
-    },
-    settleTxHash: {
-        type: String,
-        default: '',
-    },
-    bundleIndex: {
-      type: Number,
-      default: 0,
-    }
-});
+// bundleSchema moved to global-bundle schema
 
 export const randSchema = new mongoose.Schema({
     commitment: {
@@ -183,7 +149,6 @@ export const randSchema = new mongoose.Schema({
 
 export const modelTx = mongoose.model('Tx', txSchema);
 export const modelJob = mongoose.model('Job', jobSchema);
-export const modelBundle = mongoose.model('Bundle', bundleSchema);
 export const modelRand = mongoose.model('Rand', randSchema);
 
 export const ServiceHelper = new ZkWasmServiceHelper(endpoint, "", "");

--- a/ts/src/reproduce.ts
+++ b/ts/src/reproduce.ts
@@ -1,5 +1,5 @@
 import BN from "bn.js";
-import { ServiceHelper, get_contract_addr, modelBundle, get_user_private_account } from "./config.js";
+import { ServiceHelper, get_contract_addr, get_user_private_account } from "./config.js";
 import abiData from './Proxy.json' assert { type: 'json' };
 import {ZkWasmUtil, PaginationResult, QueryParams, Task, VerifyProofParams} from "zkwasm-service-helper";
 import { U8ArrayUtil } from './lib.js';

--- a/ts/src/schemas/global-bundle.ts
+++ b/ts/src/schemas/global-bundle.ts
@@ -1,0 +1,66 @@
+import mongoose from 'mongoose';
+
+export const globalBundleSchema = new mongoose.Schema({
+  merkleRoot: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true
+  },
+  preMerkleRoot: {
+    type: String,
+    default: '',
+    index: true
+  },
+  postMerkleRoot: {
+    type: String, 
+    default: '',
+    index: true
+  },
+  
+  // ZK task ID
+  taskId: {
+    type: String,
+    default: ''
+  },
+  
+  settleStatus: {
+    type: String,
+    default: 'waiting'
+  },
+  settleTxHash: {
+    type: String,
+    default: ''
+  },
+  withdrawArray: [{
+    address: { type: String, default: '' },
+    amount: { type: BigInt, default: '' }
+  }],
+  
+  // MD5 association field
+  imageMD5: {
+    type: String,
+    required: true,
+    index: true
+  },
+  
+  bundleIndex: {
+    type: Number,
+    default: 0
+  }
+});
+
+globalBundleSchema.index({ imageMD5: 1 });
+globalBundleSchema.index({ preMerkleRoot: 1, postMerkleRoot: 1 });
+globalBundleSchema.index({ merkleRoot: 1 });
+export interface IGlobalBundle extends mongoose.Document {
+  merkleRoot: string;
+  preMerkleRoot: string;
+  postMerkleRoot: string;
+  taskId: string;
+  settleStatus: string;
+  settleTxHash: string;
+  withdrawArray: Array<{ address: string; amount: string }>;
+  imageMD5: string;
+  bundleIndex: number;
+}

--- a/ts/src/schemas/global-bundle.ts
+++ b/ts/src/schemas/global-bundle.ts
@@ -32,10 +32,10 @@ export const globalBundleSchema = new mongoose.Schema({
     type: String,
     default: ''
   },
-  withdrawArray: [{
-    address: { type: String, default: '' },
-    amount: { type: BigInt, default: '' }
-  }],
+  txdata: {
+    type: Buffer,
+    default: null
+  },
   
   // MD5 association field
   imageMD5: {
@@ -60,7 +60,7 @@ export interface IGlobalBundle extends mongoose.Document {
   taskId: string;
   settleStatus: string;
   settleTxHash: string;
-  withdrawArray: Array<{ address: string; amount: string }>;
+  txdata: Buffer | null;
   imageMD5: string;
   bundleIndex: number;
 }

--- a/ts/src/service.ts
+++ b/ts/src/service.ts
@@ -213,23 +213,11 @@ export class Service {
     this.bundleIndex += 1;
     console.log("add transaction bundle:", this.bundleIndex, merkleRootToBeHexString(this.merkleRoot));
     
-    // Parse withdraw information from txdata if available
-    let withdrawArray: Array<{ address: string; amount: string }> = [];
-    if (txdata && txdata.length > 0) {
-      try {
-        const withdraws = decodeWithdraw(txdata);
-        withdrawArray = withdraws.map(withdraw => ({
-          address: withdraw.address,
-          amount: withdraw.amount.toString()
-        }));
-        console.log(`Found ${withdrawArray.length} withdrawals in txdata`);
-      } catch (error) {
-        console.warn("Failed to parse withdraw data:", error);
-      }
-    }
+    // Store raw txdata for later parsing
+    console.log(`Storing txdata of length: ${txdata ? txdata.length : 0} bytes`);
     
     try {
-      // Store to global Bundle registry with parsed withdraw data
+      // Store to global Bundle registry with raw txdata as Buffer
       await this.globalBundleService.createBundle({
         merkleRoot: merkleRootToBeHexString(this.merkleRoot),
         preMerkleRoot: preMerkleRootStr,
@@ -238,7 +226,7 @@ export class Service {
         bundleIndex: this.bundleIndex,
         settleStatus: 'waiting',
         settleTxHash: '',
-        withdrawArray: withdrawArray
+        txdata: txdata ? Buffer.from(txdata) : null
       }, this.currentMD5);
       
       console.log(`Bundle tracked globally for MD5: ${this.currentMD5}`);

--- a/ts/src/services/global-bundle-service.ts
+++ b/ts/src/services/global-bundle-service.ts
@@ -1,0 +1,75 @@
+import mongoose, { Model } from 'mongoose';
+import { globalBundleSchema, IGlobalBundle } from '../schemas/global-bundle.js';
+import { get_mongodb_uri, get_image_md5 } from '../config.js';
+
+export class GlobalBundleService {
+  private globalBundleModel: Model<IGlobalBundle>;
+  private globalConnection: mongoose.Connection;
+  
+  constructor() {
+    const globalDbUri = `${get_mongodb_uri()}/zkwasm_global_bundles`;
+    this.globalConnection = mongoose.createConnection(globalDbUri);
+    this.globalBundleModel = this.globalConnection.model<IGlobalBundle>('GlobalBundle', globalBundleSchema);
+  }
+  
+  async getAllUsedMD5s(): Promise<string[]> {
+    return await this.globalBundleModel.find().distinct('imageMD5');
+  }
+  
+  async findBundleChain(targetMerkleRoot: string): Promise<IGlobalBundle[]> {
+    console.log(`Finding bundle chain for merkleRoot: ${targetMerkleRoot}`);
+    
+    const bundles: IGlobalBundle[] = [];
+    let currentMerkleRoot = targetMerkleRoot;
+    
+    while (currentMerkleRoot) {
+      const bundle = await this.globalBundleModel.findOne({
+        merkleRoot: currentMerkleRoot
+      });
+      
+      if (!bundle) break;
+      
+      bundles.unshift(bundle);
+      currentMerkleRoot = bundle.preMerkleRoot;
+    }
+    
+    return bundles;
+  }
+  
+  
+  async createBundle(bundleData: Partial<IGlobalBundle>, imageMD5: string): Promise<IGlobalBundle> {
+    const bundle = await this.globalBundleModel.create({
+      ...bundleData,
+      imageMD5: imageMD5
+    });
+    
+    console.log(`Created global bundle: ${bundle.merkleRoot} for MD5: ${imageMD5}`);
+    return bundle;
+  }
+  
+  async updateBundle(merkleRoot: string, updateData: Partial<IGlobalBundle>): Promise<IGlobalBundle | null> {
+    return await this.globalBundleModel.findOneAndUpdate(
+      { merkleRoot: merkleRoot },
+      { $set: updateData },
+      { new: true }
+    );
+  }
+  
+  
+  async getLatestBundleForMD5(imageMD5: string): Promise<IGlobalBundle | null> {
+    return await this.globalBundleModel.findOne({
+      imageMD5: imageMD5
+    }).sort({ bundleIndex: -1 });
+  }
+  
+  async findBundleByMerkle(merkleRoot: string): Promise<IGlobalBundle | null> {
+    return await this.globalBundleModel.findOne({
+      merkleRoot: merkleRoot
+    });
+  }
+  
+  async close(): Promise<void> {
+    await this.globalConnection.close();
+  }
+}
+

--- a/ts/src/services/global-bundle-service.ts
+++ b/ts/src/services/global-bundle-service.ts
@@ -9,31 +9,12 @@ export class GlobalBundleService {
   constructor() {
     const globalDbUri = `${get_mongodb_uri()}/zkwasm_global_bundles`;
     this.globalConnection = mongoose.createConnection(globalDbUri);
+    
     this.globalBundleModel = this.globalConnection.model<IGlobalBundle>('GlobalBundle', globalBundleSchema);
   }
   
   async getAllUsedMD5s(): Promise<string[]> {
     return await this.globalBundleModel.find().distinct('imageMD5');
-  }
-  
-  async findBundleChain(targetMerkleRoot: string): Promise<IGlobalBundle[]> {
-    console.log(`Finding bundle chain for merkleRoot: ${targetMerkleRoot}`);
-    
-    const bundles: IGlobalBundle[] = [];
-    let currentMerkleRoot = targetMerkleRoot;
-    
-    while (currentMerkleRoot) {
-      const bundle = await this.globalBundleModel.findOne({
-        merkleRoot: currentMerkleRoot
-      });
-      
-      if (!bundle) break;
-      
-      bundles.unshift(bundle);
-      currentMerkleRoot = bundle.preMerkleRoot;
-    }
-    
-    return bundles;
   }
   
   

--- a/ts/src/services/migration-service.ts
+++ b/ts/src/services/migration-service.ts
@@ -1,0 +1,162 @@
+import mongoose from 'mongoose';
+import { get_mongodb_uri } from '../config.js';
+import { GlobalBundleService } from './global-bundle-service.js';
+
+export class StateMigrationService {
+  private globalBundleService: GlobalBundleService;
+  
+  constructor() {
+    this.globalBundleService = new GlobalBundleService();
+  }
+  
+  async migrateDataToMerkleRoot(targetMerkleRoot: string, newMD5: string) {
+    console.log(`Migrating business state to merkleRoot: ${targetMerkleRoot}`);
+    
+    // Verify target Bundle exists
+    const bundleChain = await this.globalBundleService.findBundleChain(targetMerkleRoot);
+    if (bundleChain.length === 0) {
+      throw new Error(`No bundle chain found for merkleRoot: ${targetMerkleRoot}`);
+    }
+    
+    console.log(`Found bundle chain with ${bundleChain.length} bundles`);
+    
+    // Migrate state snapshot data to specified merkleRoot
+    await this.migrateStateSnapshot(targetMerkleRoot, newMD5);
+    
+    console.log(`Business state migration completed to ${newMD5}`);
+    console.log(`Note: Historical records remain in original databases for reference`);
+    console.log(`Note: Account cache will rebuild automatically during usage`);
+  }
+  
+  private async migrateStateSnapshot(targetMerkleRoot: string, newMD5: string) {
+    console.log(`Migrating state snapshot for merkleRoot: ${targetMerkleRoot}`);
+    
+    const usedMD5s = await this.globalBundleService.getAllUsedMD5s();
+    const targetDbUri = `${get_mongodb_uri()}/${newMD5}_job-tracker`;
+    const targetConn = mongoose.createConnection(targetDbUri);
+    
+    let foundSnapshots = false;
+    
+    for (const sourceMD5 of usedMD5s) {
+      const sourceDbUri = `${get_mongodb_uri()}/${sourceMD5}_job-tracker`;
+      const sourceConn = mongoose.createConnection(sourceDbUri);
+      
+      try {
+        // Dynamically detect IndexedObject snapshot collections
+        const snapshotCollections = await this.detectSnapshotCollections(sourceConn);
+        console.log(`Detected snapshot collections in ${sourceMD5}: ${snapshotCollections.join(', ')}`);
+        
+        const allSnapshots: Record<string, any[]> = {};
+        let hasAnySnapshots = false;
+        
+        // Find state snapshots for target merkleRoot
+        for (const snapshotCollection of snapshotCollections) {
+          const snapshots = await sourceConn.collection(snapshotCollection)
+            .find({ merkleRoot: targetMerkleRoot }).toArray();
+          
+          if (snapshots.length > 0) {
+            allSnapshots[snapshotCollection] = snapshots;
+            hasAnySnapshots = true;
+          }
+        }
+        
+        // Event snapshots removed, no need to migrate event data
+        
+        if (hasAnySnapshots) {
+          foundSnapshots = true;
+          
+          const snapshotCounts = Object.entries(allSnapshots)
+            .map(([collection, snapshots]) => `${snapshots.length} ${collection.replace('_snapshots', '')}`)
+            .join(', ');
+          console.log(`Found snapshots in ${sourceMD5}: ${snapshotCounts}`);
+          
+          // Restore snapshot data to active state
+          for (const [snapshotCollection, snapshots] of Object.entries(allSnapshots)) {
+            // All snapshots are IndexedObject snapshots, restore to active state
+            const activeCollectionName = snapshotCollection.replace('_snapshots', '');
+            
+            const activeObjects = snapshots.map(doc => {
+              const { merkleRoot, _id, ...activeData } = doc;
+              return activeData;
+            });
+            
+            // Restore to active state
+            await targetConn.collection(activeCollectionName).insertMany(activeObjects, { ordered: false });
+            
+            // Also copy snapshot data to maintain versioning capability
+            await targetConn.collection(snapshotCollection).insertMany(snapshots, { ordered: false });
+          }
+        }
+        
+      } catch (error) {
+        console.warn(`Failed to check snapshots in ${sourceMD5}:`, error);
+      } finally {
+        await sourceConn.close();
+      }
+    }
+    
+    await targetConn.close();
+    
+    if (!foundSnapshots) {
+      console.warn(`No state snapshots found for merkleRoot: ${targetMerkleRoot}`);
+      console.warn(`This might be expected if this is the genesis state`);
+    } else {
+      console.log(`State snapshot migration completed for merkleRoot: ${targetMerkleRoot}`);
+    }
+  }
+  
+  private snapshotCollectionsCache: Map<string, string[]> = new Map();
+  
+  private async detectSnapshotCollections(connection: mongoose.Connection): Promise<string[]> {
+    const dbName = connection.db.databaseName;
+    
+    // Use cache to avoid repeated detection
+    if (this.snapshotCollectionsCache.has(dbName)) {
+      return this.snapshotCollectionsCache.get(dbName)!;
+    }
+    
+    try {
+      const collections = await connection.db.listCollections().toArray();
+      const collectionNames = collections.map(c => c.name);
+      
+      // Find collections ending with _snapshots
+      const snapshotCollections = collectionNames.filter(name => 
+        name.endsWith('_snapshots')
+      );
+      
+      console.log(`Snapshot collections in ${dbName}: ${snapshotCollections.join(', ')}`);
+      
+      // Verify IndexedObject snapshot pattern: has merkleRoot + IndexedObject interface
+      const verifiedSnapshots: string[] = [];
+      
+      for (const collectionName of snapshotCollections) {
+        try {
+          const sampleDoc = await connection.collection(collectionName).findOne({});
+          
+          // Check if it's IndexedObject snapshot: merkleRoot + {oid, object} pattern
+          if (sampleDoc && this.isIndexedObjectSnapshot(sampleDoc)) {
+            verifiedSnapshots.push(collectionName);
+            console.log(`Verified IndexedObject snapshot: ${collectionName}`);
+          }
+        } catch (error) {
+          console.warn(`Failed to verify snapshot collection ${collectionName}:`, error);
+        }
+      }
+      
+      // Cache results
+      this.snapshotCollectionsCache.set(dbName, verifiedSnapshots);
+      return verifiedSnapshots;
+      
+    } catch (error) {
+      console.warn(`Failed to detect snapshot collections in ${dbName}:`, error);
+      this.snapshotCollectionsCache.set(dbName, []);
+      return [];
+    }
+  }
+  
+  private isIndexedObjectSnapshot(doc: any): boolean {
+    return doc.merkleRoot !== undefined && 
+           doc.oid !== undefined && 
+           doc.object !== undefined;
+  }
+}

--- a/ts/src/services/migration-service.ts
+++ b/ts/src/services/migration-service.ts
@@ -7,6 +7,9 @@ const SYSTEM_COLLECTIONS = [
   'accounts', 'bundles', 'commits', 'events', 'jobs', 'rands', 'txes'
 ];
 
+// The initial/genesis merkle root that has no corresponding bundle
+const GENESIS_MERKLE_ROOT = '0xcd3f26ca390619d19789d18e2adabfe68f13f959da813b0327683708583d5ede';
+
 export class StateMigrationService {
   private globalBundleService: GlobalBundleService;
   
@@ -17,10 +20,17 @@ export class StateMigrationService {
   async migrateDataToMerkleRoot(targetMerkleRoot: string, newMD5: string) {
     console.log(`Migrating business state to merkleRoot: ${targetMerkleRoot}`);
     
-    // Verify target Bundle exists
+    // Check if this is the known genesis merkle root
+    if (targetMerkleRoot === GENESIS_MERKLE_ROOT) {
+      console.log(`Target merkleRoot is the genesis state: ${GENESIS_MERKLE_ROOT}`);
+      console.log(`No migration needed - new MD5 database ${newMD5} will start with empty state`);
+      return;
+    }
+    
+    // For non-genesis roots, verify target Bundle exists
     const targetBundle = await this.globalBundleService.findBundleByMerkle(targetMerkleRoot);
     if (!targetBundle) {
-      throw new Error(`No bundle found for merkleRoot: ${targetMerkleRoot}`);
+      throw new Error(`No bundle found for merkleRoot: ${targetMerkleRoot}. This should not happen for non-genesis roots.`);
     }
     
     console.log(`Found target bundle: ${targetMerkleRoot}`);

--- a/ts/src/services/migration-service.ts
+++ b/ts/src/services/migration-service.ts
@@ -4,7 +4,7 @@ import { GlobalBundleService } from './global-bundle-service.js';
 
 // System collections that should be excluded from business data operations
 const SYSTEM_COLLECTIONS = [
-  'accounts', 'bundles', 'commits', 'events', 'jobs', 'rands', 'txes'
+  'bundles', 'commits', 'events', 'jobs', 'rands', 'txes'
 ];
 
 // The initial/genesis merkle root that has no corresponding bundle
@@ -61,6 +61,10 @@ export class StateMigrationService {
     const targetDbUri = `${get_mongodb_uri()}/${newMD5}_job-tracker`;
     const sourceConn = mongoose.createConnection(sourceDbUri);
     const targetConn = mongoose.createConnection(targetDbUri);
+    
+    // Wait for connections to be ready
+    await sourceConn.asPromise();
+    await targetConn.asPromise();
     
     try {
       // Dynamically detect business snapshot collections
@@ -162,8 +166,7 @@ export class StateMigrationService {
       return snapshotCollections;
       
     } catch (error) {
-      const dbName = connection.db.databaseName;
-      console.warn(`Failed to detect snapshot collections in ${dbName}:`, error);
+      console.warn(`Failed to detect snapshot collections:`, error);
       return [];
     }
   }

--- a/ts/src/services/state-snapshot-service.ts
+++ b/ts/src/services/state-snapshot-service.ts
@@ -1,0 +1,148 @@
+import mongoose from 'mongoose';
+
+export class StateSnapshotService {
+  private currentMerkleRoot: string;
+  private static readonly MAX_SNAPSHOTS = 100;
+  
+  constructor(merkleRoot: string) {
+    this.currentMerkleRoot = merkleRoot;
+  }
+  
+  async createCompleteSnapshot() {
+    console.log(`Creating state snapshot for merkleRoot: ${this.currentMerkleRoot}`);
+    
+    // Dynamically detect all IndexedObject collections
+    const indexedObjectCollections = await this.detectIndexedObjectCollections();
+    console.log(`Detected IndexedObject collections: ${indexedObjectCollections.join(', ')}`);
+    
+    // Create snapshots for all detected collections
+    const snapshotTasks = indexedObjectCollections.map(collectionName => 
+      this.createSnapshotForCollection(collectionName)
+    );
+    
+    await Promise.all(snapshotTasks);
+    
+    // Cleanup excessive snapshots after creation
+    await this.cleanupExcessiveSnapshots()
+  }
+  
+  private indexedObjectCollectionsCache: string[] | null = null;
+  
+  private async detectIndexedObjectCollections(): Promise<string[]> {
+    // Use cache to avoid repeated detection
+    if (this.indexedObjectCollectionsCache !== null) {
+      return this.indexedObjectCollectionsCache;
+    }
+    
+    try {
+      const collections = await mongoose.connection.db.listCollections().toArray();
+      const collectionNames = collections.map(c => c.name);
+      
+      // Exclude system collections and snapshot collections
+      const systemCollections = [
+        'accounts', 'bundles', 'commits', 'events', 'jobs', 'rands', 'txes',
+        ...collectionNames.filter(name => name.endsWith('_snapshots'))
+      ];
+      
+      const candidateCollections = collectionNames.filter(name => 
+        !systemCollections.includes(name)
+      );
+      
+      console.log(`Candidate IndexedObject collections: ${candidateCollections.join(', ')}`);
+      
+      // Verify if it matches IndexedObject interface: {oid: bigint, object: O}
+      const indexedObjectCollections: string[] = [];
+      
+      for (const collectionName of candidateCollections) {
+        try {
+          const sampleDoc = await mongoose.connection.collection(collectionName).findOne({});
+          
+          // Check if it matches IndexedObject interface pattern
+          if (sampleDoc && this.hasIndexedObjectInterface(sampleDoc)) {
+            indexedObjectCollections.push(collectionName);
+            console.log(`Confirmed IndexedObject collection: ${collectionName}`);
+          }
+        } catch (error) {
+          console.warn(`Failed to check collection ${collectionName}:`, error);
+        }
+      }
+      
+      // Cache results
+      this.indexedObjectCollectionsCache = indexedObjectCollections;
+      return indexedObjectCollections;
+      
+    } catch (error) {
+      console.warn(`Failed to detect IndexedObject collections:`, error);
+      this.indexedObjectCollectionsCache = [];
+      return [];
+    }
+  }
+  
+  private hasIndexedObjectInterface(doc: any): boolean {
+    return doc.oid !== undefined && doc.object !== undefined;
+  }
+  
+  private async createSnapshotForCollection(collectionName: string) {
+    try {
+      // Get current active objects directly from MongoDB
+      const activeObjects = await mongoose.connection.collection(collectionName).find({}).toArray();
+      
+      if (activeObjects.length === 0) {
+        console.log(`No active objects found for ${collectionName}`);
+        return;
+      }
+      
+      // Create snapshot copies for current state
+      const snapshots = activeObjects.map(obj => ({
+        ...obj,
+        merkleRoot: this.currentMerkleRoot,
+        _id: undefined
+      }));
+      
+      // Batch insert snapshot data using MongoDB native operations
+      await mongoose.connection.collection(`${collectionName}_snapshots`).insertMany(snapshots, { ordered: false });
+      console.log(`Created ${snapshots.length} snapshots for ${collectionName}`);
+      
+    } catch (error) {
+      console.warn(`Failed to create snapshots for ${collectionName}:`, error);
+    }
+  }
+  
+  private async cleanupExcessiveSnapshots() {
+    const indexedObjectCollections = await this.detectIndexedObjectCollections();
+    
+    for (const collectionName of indexedObjectCollections) {
+      const snapshotCollectionName = `${collectionName}_snapshots`;
+      
+      try {
+        // Get all snapshots grouped by merkleRoot
+        const allSnapshots = await mongoose.connection.collection(snapshotCollectionName)
+          .aggregate([
+            { $group: { _id: "$merkleRoot", count: { $sum: 1 }, firstDoc: { $first: "$$ROOT" } } },
+            { $sort: { "firstDoc._id": -1 } }
+          ]).toArray();
+        
+        if (allSnapshots.length > StateSnapshotService.MAX_SNAPSHOTS) {
+          // Get merkleRoot list of old snapshots to delete
+          const excessSnapshots = allSnapshots.slice(StateSnapshotService.MAX_SNAPSHOTS);
+          const merkleRootsToDelete = excessSnapshots.map(s => s._id);
+          
+          // Delete excessive snapshots
+          const deleteResult = await mongoose.connection.collection(snapshotCollectionName)
+            .deleteMany({ merkleRoot: { $in: merkleRootsToDelete } });
+          
+          console.log(`Cleaned up ${deleteResult.deletedCount} excessive snapshots from ${snapshotCollectionName}`);
+        }
+      } catch (error) {
+        console.warn(`Failed to cleanup excessive snapshots for ${snapshotCollectionName}:`, error);
+      }
+    }
+  }
+  
+  
+  
+  updateMerkleRoot(newMerkleRoot: string) {
+    this.currentMerkleRoot = newMerkleRoot;
+  }
+}
+

--- a/ts/src/storage/object.ts
+++ b/ts/src/storage/object.ts
@@ -57,7 +57,7 @@ export function fromData<O>(u64datasource: bigint[], decoder: Decodable<O>): Obj
 export function createObjectSchema(ObjectSchema: SchemaType) {
     // Define the schema for the Token model
     const objectSchema = new mongoose.Schema({
-        id: { type: BigInt, required: true, unique: true},
+        oid: { type: BigInt, required: true, unique: true},
         object: { type: ObjectSchema, require: true},
     });
     objectSchema.pre('init', uint64FetchPlugin);

--- a/ts/src/withdraw_analysis.ts
+++ b/ts/src/withdraw_analysis.ts
@@ -1,5 +1,6 @@
 import BN from "bn.js";
-import { ServiceHelper, get_mongoose_db, get_contract_addr, get_image_md5, modelBundle, get_settle_private_account } from "./config.js";
+import { ServiceHelper, get_mongoose_db, get_contract_addr, get_image_md5, get_settle_private_account } from "./config.js";
+import { GlobalBundleService } from "./services/global-bundle-service.js";
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
 
@@ -10,26 +11,42 @@ mongoose.connect(get_mongoose_db(), {
 
 async function analyzeWithdrawals() {
 	try {
-		const bundles = await modelBundle.find();
-
+		const globalBundleService = new GlobalBundleService();
+		
+		// Get all MD5s and analyze withdrawals for each
+		const allMD5s = await globalBundleService.getAllUsedMD5s();
+		console.log(`Found ${allMD5s.length} different MD5 versions`);
+		
 		let totalWithdrawals = 0;
 		let uniqueAddresses = new Set();
 		let totalAmount = BigInt(0);
 
-		bundles.forEach(bundle => {
-			if (bundle.withdrawArray && bundle.withdrawArray.length > 0) {
-				totalWithdrawals += bundle.withdrawArray.length;
+		for (const md5 of allMD5s) {
+			console.log(`\nAnalyzing withdrawals for MD5: ${md5}`);
+			
+			// Get all bundles for this MD5
+			const bundles = await globalBundleService.getAllBundlesForMD5(md5);
+			console.log(`Found ${bundles.length} bundles for this MD5`);
+			
+			bundles.forEach(bundle => {
+				if (bundle.withdrawArray && bundle.withdrawArray.length > 0) {
+					totalWithdrawals += bundle.withdrawArray.length;
 
-				bundle.withdrawArray.forEach(withdraw => {
-					uniqueAddresses.add(withdraw.address);
-					totalAmount += BigInt(withdraw.amount);
-				});
-			}
-		});
+					bundle.withdrawArray.forEach(withdraw => {
+						uniqueAddresses.add(withdraw.address);
+						totalAmount += BigInt(withdraw.amount);
+					});
+				}
+			});
+		}
 
+		console.log(`\n=== Withdrawal Analysis Results ===`);
 		console.log(`Total Withdrawals: ${totalWithdrawals}`);
 		console.log(`Unique Addresses: ${uniqueAddresses.size}`);
 		console.log(`Total Amount Withdrawn: ${totalAmount.toString()}`); //In wei
+		
+		await globalBundleService.close();
+		
 	} catch (error) {
 		console.error('Error analyzing withdrawals:', error);
 	}


### PR DESCRIPTION
- Add global Bundle registry to break MD5 circular dependencies
- Implement state snapshot system with quantity limits (max 100)
- Add cross-database migration service for Bundle chain recovery
- Fix ObjectEvent field mismatch: id -> oid for proper upsert behavior
- Remove unnecessary event snapshot functionality
- Add comprehensive English documentation